### PR TITLE
Implemented back-to-close functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-all: icon.png icon64.png
+.PHONY += all
+all: scrolling-gestures.xpi
+
+.PHONY += clean
+clean:
+	@rm ./scrolling-gestures.xpi
+	@rm ./icon.png
+	@rm ./icon64.png
 
 icon.png: icon.svg
 	inkscape -e icon.png_ -w 48 icon.svg
@@ -11,9 +18,10 @@ icon64.png: icon.svg
 
 test: all
 	jpm run -b ~/opt/firefox/firefox
+
 dist: scrolling-gestures.xpi
 
-scrolling-gestures.xpi: all
+scrolling-gestures.xpi: package.json lib/main.js icon.png icon64.png
 	perl update-buildnum.pl package.json
 	jpm xpi
 	mv jid0-xXJ39NPeSBeN8zbjffQa2GIA7kQ@jetpack-*.xpi $@

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,6 +37,7 @@ var gestureLength = 11;
 var gestureUnlockTimeout = 100;
 var gestureReverse = 1;         // -1 = Reverse, 1 = Not reversed
 var gestureFeedback = 1;
+var gestureCloseTabs = 1;	// -1 = Off, 1 = On
 
 // In-page workers for visual feedback
 var workerCache = undefined;
@@ -190,10 +191,17 @@ function recognizeGesture(event, wnd) {
     if ( eventLength >= gestureLength ) {
         if ( debug )
             console.log("Triggered gesture " + eventDirection);
-        // Send a history navigation event to the tab
-        tab.attach({
-            contentScript: 'history.go(' + eventDirection*gestureReverse + ')'
-        });
+        // Send a history navigation event to the tab, or close it if no more history is available
+	var history = wnd.SessionStore.getSessionHistory(wnd.getBrowser().selectedTab);
+	var closeTab = ( gestureCloseTabs == 1 && eventDirection*gestureReverse < 0 );
+	closeTab &= ( history == undefined || history.index == 0);
+	if ( closeTab ) {
+		tab.close();
+	} else if ( eventDirection*gestureReverse < 0 ) {
+		wnd.gBrowser.webNavigation.goBack();
+	} else {
+		wnd.gBrowser.webNavigation.goForward();
+	}
         // Invalidate the current gesture
         eventWindow = 0;
         eventLocked = true;
@@ -265,6 +273,7 @@ function updatePrefs() {
     gestureUnlockTimeout = prefs.prefs.gestureUnlockTimeout;
     gestureReverse = prefs.prefs.gestureReverse;
     gestureFeedback = prefs.prefs.gestureFeedback;
+    gestureCloseTabs = prefs.prefs.gestureCloseTabs;
     console.log("Prefs updated: " + gestureTimeout + " " + gestureLength +
                 " " + gestureUnlockTimeout + " " + gestureReverse +
                 " " + gestureFeedback);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "Navigate your browser history with horizontal scrolling on your trackpad or mouse wheel, while still being able to scroll left and right.",
     "author": "nandhp",
     "license": "MPL 2.0",
-    "version": "1.1.0223",
+    "version": "1.1.0224",
 
     "homepage": "https://github.com/nandhp/scrolling-gestures",
     "icon": "icon.png",
@@ -53,6 +53,15 @@
             "off": "1",
             "value": 1,
             "name": "gestureReverse"
+        },
+        {
+            "title": "Automatically close tabs",
+            "type": "boolint",
+            "description": "Close tabs automatically if going back and no history is available",
+            "on": "1",
+            "off": "-1",
+            "value": 1,
+            "name": "gestureCloseTabs"
         }
     ]
 }


### PR DESCRIPTION
Nice plugin, thanks, it's working well under Linux with libinput!

But I was missing back-to-close behaviour I have when using a mouse (via an extra add-on called Back-to-close), so I decided to extend your plugin a bit. Also, sometimes on chrome tabs the navigation wasn't working properly so I fixed that as well and improved your Makefile a bit.
